### PR TITLE
Adjust the upper bound of the port cmd to work better with node::net

### DIFF
--- a/cmd/port.go
+++ b/cmd/port.go
@@ -24,10 +24,10 @@ func init() {
 
 func runPortCmd(cmd *cobra.Command, args []string) {
 	var start int = 1024
-	var end int = 66535
+	var end int = 65535
 
 	if len(args) > 0 {
-		s, e, err := utils.IntRangeFromString(args[0], 1024, 66535)
+		s, e, err := utils.IntRangeFromString(args[0], 1024, 65535)
 		if err != nil {
 			log.Fatalf("invalid int range: %s", err.Error())
 		}


### PR DESCRIPTION
Adjust the upper bound of the port cmd to 65535 to work better with `node::net`.

Looks like the [comment](https://github.com/tinacious/random/blob/0ca32127af7e8ae317214d47bbb35209151bac8a/cmd/port.go#L17) was correct so this was likely a typo.

Closes #1 